### PR TITLE
fix(*): support same token to be injected twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Yarn
-        run: yarn --frozen-lockfile && lerna bootstrap --ci
+        run: yarn --frozen-lockfile
 
       - name: Build
         run: yarn build
@@ -49,7 +49,7 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Yarn
-        run: yarn --frozen-lockfile && lerna bootstrap --ci
+        run: yarn --frozen-lockfile
 
       - name: Lint
         run: yarn lint
@@ -75,7 +75,7 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Yarn
-        run: yarn --frozen-lockfile && lerna bootstrap --ci
+        run: yarn --frozen-lockfile
 
       - name: Test
         run: yarn jest --selectProjects ${{ matrix.project }} --coverage --verbose --passWithNoTests

--- a/packages/adapters/nestjs/__test__/integration.assets.ts
+++ b/packages/adapters/nestjs/__test__/integration.assets.ts
@@ -1,5 +1,7 @@
 import { forwardRef, Inject } from '@nestjs/common';
 
+type DummyType = string;
+
 export class DependencyOne {
   print(): string {
     return 'dependencyOne';
@@ -30,6 +32,7 @@ export class MainClass {
     private readonly dependencyTwo: DependencyTwo,
     @Inject(forwardRef(() => DependencyThree)) private readonly dependencyThree: DependencyThree,
     @Inject('CUSTOM_TOKEN') private readonly dependencyFour: DependencyFourToken,
+    @Inject('CUSTOM_TOKEN') private readonly dummy: DummyType,
     @Inject('LITERAL_VALUE_ARR') private readonly literalValueArray: string[],
     @Inject('LITERAL_VALUE_STR') private readonly literalValueString: string
   ) {}

--- a/packages/adapters/nestjs/__test__/nestjs-adapter.integration.test.ts
+++ b/packages/adapters/nestjs/__test__/nestjs-adapter.integration.test.ts
@@ -7,8 +7,7 @@ import {
   DependencyTwo,
   MainClass,
 } from './integration.assets';
-import { Type } from '@automock/types';
-import { ClassDependencies, PrimitiveValue } from '@automock/common';
+import { ClassDependenciesMap } from '@automock/common';
 
 describe('NestJS Automock Adapter Integration Test', () => {
   describe('reflecting a class', () => {
@@ -16,16 +15,15 @@ describe('NestJS Automock Adapter Integration Test', () => {
     const classDependencies = reflectorFactory.reflectDependencies(MainClass);
 
     it('should return a map of the class dependencies', () => {
-      expect(classDependencies).toStrictEqual<ClassDependencies>(
-        new Map<Type | string, PrimitiveValue | Type>([
-          ['CUSTOM_TOKEN', DependencyFourToken],
-          [DependencyOne, DependencyOne],
-          [DependencyTwo, DependencyTwo],
-          [DependencyThree, DependencyThree],
-          ['LITERAL_VALUE_ARR', Array],
-          ['LITERAL_VALUE_STR', String],
-        ])
-      );
+      expect(classDependencies.constructor).toStrictEqual<ClassDependenciesMap['constructor']>([
+        [DependencyOne, DependencyOne],
+        [DependencyTwo, DependencyTwo],
+        [DependencyThree, DependencyThree],
+        ['CUSTOM_TOKEN', DependencyFourToken],
+        ['CUSTOM_TOKEN', String],
+        ['LITERAL_VALUE_ARR', Array],
+        ['LITERAL_VALUE_STR', String],
+      ]);
     });
   });
 });

--- a/packages/adapters/nestjs/src/reflector.service.ts
+++ b/packages/adapters/nestjs/src/reflector.service.ts
@@ -1,9 +1,6 @@
 import { Type } from '@automock/types';
-import {
-  ClassDependencies,
-  DependenciesReflector as AutomockDependenciesReflector,
-  PrimitiveValue,
-} from '@automock/common';
+import { ClassDependencies, ClassDependenciesMap } from '@automock/common';
+import { DependenciesReflector as AutomockDependenciesReflector } from '@automock/common';
 import { CustomToken, TokensReflector } from './token-reflector.service';
 
 const INJECTED_TOKENS_METADATA = 'self:paramtypes';
@@ -13,10 +10,10 @@ export function ReflectorFactory(
   reflector: typeof Reflect,
   tokensReflector: TokensReflector
 ): AutomockDependenciesReflector {
-  function reflectDependencies(targetClass: Type): ClassDependencies {
+  function reflectDependencies(targetClass: Type): ClassDependenciesMap {
     const types = reflectParamTypes(targetClass);
     const tokens = reflectParamTokens(targetClass);
-    const classDependencies: ClassDependencies = new Map<Type | string, PrimitiveValue | Type>();
+    const classDependencies: ClassDependencies = [];
 
     const callback = tokensReflector.attachTokenToDependency(tokens);
 
@@ -30,12 +27,9 @@ export function ReflectorFactory(
           );
         }
       })
-      .forEach((tuple) => {
-        const [typeOrToken, type] = tuple;
-        classDependencies.set(typeOrToken, type);
-      });
+      .forEach((tuple) => classDependencies.push(tuple));
 
-    return classDependencies;
+    return { constructor: classDependencies };
   }
 
   function reflectParamTokens(targetClass: Type): CustomToken[] {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -2,8 +2,12 @@ import { Type } from '@automock/types';
 
 export type PrimitiveValue = string | number | boolean | symbol | null;
 
-export type ClassDependencies = Map<Type | string, Type | PrimitiveValue>;
+export type ClassDependencies = [Type | string, PrimitiveValue | Type][];
+
+export interface ClassDependenciesMap {
+  constructor: ClassDependencies;
+}
 
 export interface DependenciesReflector {
-  reflectDependencies(targetClass: Type): ClassDependencies;
+  reflectDependencies(targetClass: Type): ClassDependenciesMap;
 }

--- a/packages/core/__test__/testbed-builder.integration.test.ts
+++ b/packages/core/__test__/testbed-builder.integration.test.ts
@@ -9,7 +9,7 @@ import {
   DependencyTwo,
   DependencyFive,
 } from './integration.assets';
-import { PrimitiveValue } from '@automock/common';
+import { DependenciesReflector } from '@automock/common';
 
 describe('Builder Factory Integration Test', () => {
   let underTest: TestBedBuilder<MainClass>;
@@ -18,16 +18,22 @@ describe('Builder Factory Integration Test', () => {
   const mockFunctionMockOfBuilder = jest.fn(() => '__MOCKED_FROM_BUILDER__');
   const mockFunctionMockOfMocker = jest.fn(() => '__MOCKED_FROM_MOCKER__');
 
-  const reflectorMock = {
+  const reflectorMock: DependenciesReflector = {
     reflectDependencies: () => {
-      return new Map<Type | string, Type | PrimitiveValue>([
-        [DependencyOne, DependencyOne],
-        [DependencyTwo, DependencyTwo],
-        [DependencyThree, DependencyThree],
-        ['DEPENDENCY_FOUR_TOKEN', DependencyFourToken],
-        [DependencyFive, DependencyFive],
-        ['STRING_TOKEN', 'ANY STRING'],
-      ]);
+      return {
+        constructor: [
+          [DependencyOne, DependencyOne],
+          // Repeat on the same dependency twice, as it can be returned from the reflector (@since 1.2.2)
+          [DependencyTwo, DependencyTwo],
+          [DependencyTwo, DependencyTwo],
+          [DependencyThree, DependencyThree],
+          // Repeat on the same dependency twice, as it can be returned from the reflector (@since 1.2.2)
+          ['DEPENDENCY_FOUR_TOKEN', DependencyFourToken],
+          ['DEPENDENCY_FOUR_TOKEN', DependencyFourToken],
+          [DependencyFive, DependencyFive],
+          ['STRING_TOKEN', 'ANY STRING'],
+        ],
+      };
     },
   };
 
@@ -75,6 +81,7 @@ describe('Builder Factory Integration Test', () => {
     describe('override the dependencies from the builder, and leave the rest for the dependencies mocked', () => {
       it.each([
         [DependencyOne.name, '__MOCKED_FROM_BUILDER__', DependencyOne],
+        [DependencyTwo.name, '__MOCKED_FROM_BUILDER__', DependencyTwo],
         [DependencyTwo.name, '__MOCKED_FROM_BUILDER__', DependencyTwo],
         [DependencyThree.name, '__MOCKED_FROM_MOCKER__', DependencyThree],
         ['custom token with function', '__MOCKED_FROM_BUILDER__', 'DEPENDENCY_FOUR_TOKEN'],

--- a/packages/core/src/services/dependencies-mocker.spec.ts
+++ b/packages/core/src/services/dependencies-mocker.spec.ts
@@ -1,5 +1,7 @@
 import { DependenciesMocker } from './dependencies-mocker';
 import { Type } from '@automock/types';
+import { DependenciesReflector } from '@automock/common';
+import MockedFn = jest.MockedFn;
 
 class SomeClassOne {}
 
@@ -11,7 +13,9 @@ const MOCKED = '__MOCKED__';
 describe('Dependencies Mocker Unit Spec', () => {
   let underTest: DependenciesMocker;
   const mockFunctionStub = () => MOCKED;
-  const reflectorMock = { reflectDependencies: jest.fn() };
+  const reflectorMock = {
+    reflectDependencies: jest.fn() as MockedFn<DependenciesReflector['reflectDependencies']>,
+  };
 
   beforeAll(() => {
     underTest = new DependenciesMocker(reflectorMock, mockFunctionStub);
@@ -19,13 +23,13 @@ describe('Dependencies Mocker Unit Spec', () => {
 
   describe('mocking all class dependencies', () => {
     beforeAll(() => {
-      reflectorMock.reflectDependencies.mockReturnValue(
-        new Map<Type | string, Type>([
+      reflectorMock.reflectDependencies.mockReturnValue({
+        constructor: [
           [SomeClassOne, SomeClassOne],
           [SomeClassTwo, SomeClassTwo],
           ['TOKEN', ClassFromToken],
-        ])
-      );
+        ],
+      });
     });
 
     describe('assuming there is only one mocked class in the given dependencies', () => {

--- a/packages/core/src/services/dependencies-mocker.ts
+++ b/packages/core/src/services/dependencies-mocker.ts
@@ -22,7 +22,7 @@ export class DependenciesMocker {
       const classDependencies = this.reflector.reflectDependencies(targetClass);
       const classMockedDependencies = new Map<Type | string, StubbedInstance<unknown>>();
 
-      for (const [dependency] of classDependencies.entries()) {
+      for (const [dependency] of classDependencies.constructor) {
         const alreadyMocked = alreadyMockedDependencies.get(dependency);
 
         const mockedDependency = alreadyMocked


### PR DESCRIPTION
## Description

In this pull request, significant changes have been made to the `DependenciesReflector` interface in the `@automock/common` package. The reflector has been updated to utilize tuples instead of the previous Map implementation for reflecting dependencies. This modification is crucial as it allows the reflector to effectively handle the injection of the same token or class multiple times, which was not feasible with the previous Map-based approach.

To ensure consistency and compatibility, corresponding changes have been made in the `@automock/core` and `@automock/adapters.nestjs` packages. These adjustments ensure that both packages now support the tuple-based type instead of relying on the previous Map-based implementation.

Closes #67 