### PR TITLE
chore: remove assets from coverage collection

### DIFF
--- a/packages/adapters/nestjs/jest.config.ts
+++ b/packages/adapters/nestjs/jest.config.ts
@@ -5,8 +5,8 @@ const config: Config = {
   ...baseConfig,
   id: 'adapters.nestjs',
   displayName: 'adapters.nestjs',
-  collectCoverageFrom: ['src/**/*.ts', '__test__/**/*.ts'],
-  coveragePathIgnorePatterns: ['index.ts', '__test__/integration.assets.ts'],
+  collectCoverageFrom: ['src/**/*.ts'],
+  coveragePathIgnorePatterns: ['index.ts', '__test__/**/*.ts'],
 };
 
 export default config;

--- a/packages/adapters/nestjs/jest.config.ts
+++ b/packages/adapters/nestjs/jest.config.ts
@@ -6,7 +6,7 @@ const config: Config = {
   id: 'adapters.nestjs',
   displayName: 'adapters.nestjs',
   collectCoverageFrom: ['src/**/*.ts'],
-  coveragePathIgnorePatterns: ['index.ts', '__test__/**/*.ts'],
+  coveragePathIgnorePatterns: ['index.ts', '__test__/assets/integration.assets.ts'],
 };
 
 export default config;


### PR DESCRIPTION
Remove the `assets` folder from coverage collection as it is not related to actual files