### PR TITLE
fix(core.unit,unit): prevent .mock() from being called immediately after .sociable()

### DIFF
--- a/packages/core/__test__/sociable-empty-constructor/sociable-testbed-builder-empty-constructor.integration.test.ts
+++ b/packages/core/__test__/sociable-empty-constructor/sociable-testbed-builder-empty-constructor.integration.test.ts
@@ -6,7 +6,7 @@ import {
 import { FakeAdapter } from './assets/integration.assets';
 import { mock } from '../mock.static';
 import type { UnitReference } from '../../src';
-import { SociableTestBedBuilder, UnitMocker } from '../../src';
+import { SociableTestBedBuilderImpl, UnitMocker } from '../../src';
 
 describe('Social TestBed Builder (Empty Constructor) Integration Tests', () => {
   let unitBuilder: SociableTestBedBuilder<TestService>;
@@ -16,7 +16,7 @@ describe('Social TestBed Builder (Empty Constructor) Integration Tests', () => {
   const loggerMock = { warn: jest.fn() } as unknown as jest.Mocked<Console>;
 
   beforeAll(async () => {
-    unitBuilder = new SociableTestBedBuilder(
+    unitBuilder = new SociableTestBedBuilderImpl(
       Promise.resolve({
         mock: mock,
         stub: jest.fn,

--- a/packages/core/__test__/sociable/boundaries-feature.integration.test.ts
+++ b/packages/core/__test__/sociable/boundaries-feature.integration.test.ts
@@ -9,7 +9,7 @@ import {
   DatabaseService,
   UserDigestService,
 } from './assets/injectable-registry.fixture';
-import { SociableTestBedBuilder, UnitMocker } from '../../src';
+import { SociableTestBedBuilderImpl, UnitMocker } from '../../src';
 
 describe('Boundaries Feature - Internal Resolution Mechanics', () => {
   const loggerMock = mock<Console>();
@@ -20,7 +20,7 @@ describe('Boundaries Feature - Internal Resolution Mechanics', () => {
 
   describe('Resolution: Explicit mock (Priority 1) beats boundary (Priority 2)', () => {
     it('should use explicit mock when dependency is both in boundaries and mocked', async () => {
-      const unitBuilder = new SociableTestBedBuilder(
+      const unitBuilder = new SociableTestBedBuilderImpl(
         Promise.resolve({ mock, stub: jest.fn }),
         new UnitMocker(Promise.resolve(mock), Promise.resolve(FakeAdapter)),
         UserService,
@@ -58,7 +58,7 @@ describe('Boundaries Feature - Internal Resolution Mechanics', () => {
 
   describe('boundaries() no-arg overload', () => {
     it('should accept no arguments (same as empty array)', async () => {
-      const unitBuilder = new SociableTestBedBuilder(
+      const unitBuilder = new SociableTestBedBuilderImpl(
         Promise.resolve({ mock, stub: jest.fn }),
         new UnitMocker(Promise.resolve(mock), Promise.resolve(FakeAdapter)),
         UserService,
@@ -90,7 +90,7 @@ describe('Boundaries Feature - Internal Resolution Mechanics', () => {
 
   describe('CRITICAL: Retrieval rules in boundaries mode', () => {
     it('should ALLOW retrieving boundary classes (mocked) but NOT auto-exposed classes (real)', async () => {
-      const unitBuilder = new SociableTestBedBuilder(
+      const unitBuilder = new SociableTestBedBuilderImpl(
         Promise.resolve({ mock, stub: jest.fn }),
         new UnitMocker(Promise.resolve(mock), Promise.resolve(FakeAdapter)),
         UserService,
@@ -127,7 +127,7 @@ describe('Boundaries Feature - Internal Resolution Mechanics', () => {
 
   describe('Resolution: Boundaries mode enables auto-expose', () => {
     it('should compile with boundaries mode', async () => {
-      const unitBuilder = new SociableTestBedBuilder(
+      const unitBuilder = new SociableTestBedBuilderImpl(
         Promise.resolve({ mock, stub: jest.fn }),
         new UnitMocker(Promise.resolve(mock), Promise.resolve(FakeAdapter)),
         UserService,
@@ -150,7 +150,7 @@ describe('Boundaries Feature - Internal Resolution Mechanics', () => {
     });
 
     it('should auto-expose leaf classes that are not in boundaries', async () => {
-      const unitBuilder = new SociableTestBedBuilder(
+      const unitBuilder = new SociableTestBedBuilderImpl(
         Promise.resolve({ mock, stub: jest.fn }),
         new UnitMocker(Promise.resolve(mock), Promise.resolve(FakeAdapter)),
         UserService,
@@ -197,7 +197,7 @@ describe('Boundaries Feature - Internal Resolution Mechanics', () => {
     // where we have full NestJS DI and real service registries
 
     it('should fail-fast for unconfigured dependency in expose mode', async () => {
-      const unitBuilder = new SociableTestBedBuilder(
+      const unitBuilder = new SociableTestBedBuilderImpl(
         Promise.resolve({ mock, stub: jest.fn }),
         new UnitMocker(Promise.resolve(mock), Promise.resolve(FakeAdapter)),
         UserService,
@@ -209,7 +209,7 @@ describe('Boundaries Feature - Internal Resolution Mechanics', () => {
     });
 
     it('should NOT fail when failFast is disabled', async () => {
-      const unitBuilder = new SociableTestBedBuilder(
+      const unitBuilder = new SociableTestBedBuilderImpl(
         Promise.resolve({ mock, stub: jest.fn }),
         new UnitMocker(Promise.resolve(mock), Promise.resolve(FakeAdapter)),
         UserService,
@@ -222,7 +222,7 @@ describe('Boundaries Feature - Internal Resolution Mechanics', () => {
     });
 
     it('should log warning when failFast is disabled', () => {
-      const unitBuilder = new SociableTestBedBuilder(
+      const unitBuilder = new SociableTestBedBuilderImpl(
         Promise.resolve({ mock, stub: jest.fn }),
         new UnitMocker(Promise.resolve(mock), Promise.resolve(FakeAdapter)),
         UserService,
@@ -240,7 +240,7 @@ describe('Boundaries Feature - Internal Resolution Mechanics', () => {
     // with full DI context where auto-expose can properly trigger fail-fast
 
     it('should format error message for null mode when fail-fast triggers', async () => {
-      const unitBuilder = new SociableTestBedBuilder(
+      const unitBuilder = new SociableTestBedBuilderImpl(
         Promise.resolve({ mock, stub: jest.fn }),
         new UnitMocker(Promise.resolve(mock), Promise.resolve(FakeAdapter)),
         UserService,
@@ -261,7 +261,7 @@ describe('Boundaries Feature - Internal Resolution Mechanics', () => {
         },
       } as any;
 
-      const unitBuilder = new SociableTestBedBuilder(
+      const unitBuilder = new SociableTestBedBuilderImpl(
         Promise.resolve({ mock, stub: jest.fn }),
         new UnitMocker(Promise.resolve(mock), Promise.resolve(badAdapter)),
         UserService,
@@ -274,7 +274,7 @@ describe('Boundaries Feature - Internal Resolution Mechanics', () => {
     });
 
     it('should format error message for expose mode with helpful suggestions', async () => {
-      const unitBuilder = new SociableTestBedBuilder(
+      const unitBuilder = new SociableTestBedBuilderImpl(
         Promise.resolve({ mock, stub: jest.fn }),
         new UnitMocker(Promise.resolve(mock), Promise.resolve(FakeAdapter)),
         UserService,
@@ -291,7 +291,7 @@ describe('Boundaries Feature - Internal Resolution Mechanics', () => {
 
   describe('Error message formatting', () => {
     it('should include helpful context in expose mode error', async () => {
-      const unitBuilder = new SociableTestBedBuilder(
+      const unitBuilder = new SociableTestBedBuilderImpl(
         Promise.resolve({ mock, stub: jest.fn }),
         new UnitMocker(Promise.resolve(mock), Promise.resolve(FakeAdapter)),
         UserService,
@@ -302,7 +302,7 @@ describe('Boundaries Feature - Internal Resolution Mechanics', () => {
     });
 
     it('should format error message for null mode', async () => {
-      const unitBuilder = new SociableTestBedBuilder(
+      const unitBuilder = new SociableTestBedBuilderImpl(
         Promise.resolve({ mock, stub: jest.fn }),
         new UnitMocker(Promise.resolve(mock), Promise.resolve(FakeAdapter)),
         UserService,
@@ -314,7 +314,7 @@ describe('Boundaries Feature - Internal Resolution Mechanics', () => {
     });
 
     it('should provide migration path in error message', async () => {
-      const unitBuilder = new SociableTestBedBuilder(
+      const unitBuilder = new SociableTestBedBuilderImpl(
         Promise.resolve({ mock, stub: jest.fn }),
         new UnitMocker(Promise.resolve(mock), Promise.resolve(FakeAdapter)),
         UserService,

--- a/packages/core/__test__/sociable/sociable-testbed-builder.integration.test.ts
+++ b/packages/core/__test__/sociable/sociable-testbed-builder.integration.test.ts
@@ -14,7 +14,7 @@ import {
   DatabaseService,
 } from './assets/injectable-registry.fixture';
 import type { UnitReference } from '../../src';
-import { SociableTestBedBuilder, UnitMocker } from '../../src';
+import { SociableTestBedBuilderImpl, UnitMocker } from '../../src';
 import Mock = jest.Mock;
 
 describe('Social TestBed Builder Integration Tests', () => {
@@ -25,7 +25,7 @@ describe('Social TestBed Builder Integration Tests', () => {
   const loggerMock = mock<Console>();
 
   beforeAll(async () => {
-    unitBuilder = new SociableTestBedBuilder(
+    unitBuilder = new SociableTestBedBuilderImpl(
       Promise.resolve({
         mock: mock,
         stub: jest.fn,
@@ -154,6 +154,7 @@ describe('Social TestBed Builder Integration Tests', () => {
 
   it('should trigger the logger warning when the HttpClient is attempted to be mocked', async () => {
     await unitBuilder
+      .expose(UserApiService) // Must call expose or boundaries before mock
       .mock('non-existing-dep')
       .impl(() => ({}))
       .compile();
@@ -165,6 +166,7 @@ describe('Social TestBed Builder Integration Tests', () => {
 
   it('should trigger the logger warning when the HttpClient is attempted to be mocked', async () => {
     await unitBuilder
+      .expose(UserApiService) // Must call expose or boundaries before mock
       .mock(UserDal)
       .impl(() => ({}))
       .compile();

--- a/packages/core/src/services/builders/sociable-unit-builder.ts
+++ b/packages/core/src/services/builders/sociable-unit-builder.ts
@@ -147,6 +147,9 @@ export interface SociableTestBedBuilderInBoundariesMode<TClass> extends TestBedB
  * - Use **expose mode** when you want fine-grained control (few real dependencies)
  * - Use **boundaries mode** when most dependencies should be real (few boundaries)
  *
+ * **Note:** The `.mock()` method is NOT available at this stage.
+ * Call `.expose()` or `.boundaries()` first to access `.mock()` for custom configurations.
+ *
  * @template TClass The type of the class under test
  * @since 4.0.0
  * @see https://suites.dev/docs/api-reference/testbed-sociable
@@ -164,7 +167,7 @@ export interface SociableTestBedBuilderInBoundariesMode<TClass> extends TestBedB
  *   .boundaries([RecommendationEngine, CacheService])
  *   .compile();
  */
-export interface SociableTestBedBuilder<TClass> extends TestBedBuilder<TClass> {
+export interface SociableTestBedBuilder<TClass> {
   /**
    * Declares a dependency to be exposed (made real) in the test.
    * Switches the builder to **expose mode** (whitelist strategy).
@@ -277,15 +280,19 @@ export interface SociableTestBedBuilder<TClass> extends TestBedBuilder<TClass> {
 }
 
 /**
- * Builder for creating sociable unit tests with configurable dependency behavior.
- * Supports two mutually exclusive modes:
- * - Expose mode: Explicitly declare which dependencies should be real (default mocks everything)
- * - Boundaries mode: Explicitly declare which dependencies should be mocked (default makes everything real)
+ * @internal
+ * Internal implementation class for SociableTestBedBuilder.
+ *
+ * This class is exported for framework usage but should not be used directly by consumers.
+ * Use `TestBed.sociable()` factory method which returns the `SociableTestBedBuilder` interface type.
+ *
+ * The class name is intentionally different from the interface to prevent TypeScript's declaration
+ * merging, which would expose the inherited `.mock()` method in the public API.
  *
  * @template TClass The type of the class under test
  * @since 3.0.0
  */
-export class SociableTestBedBuilder<TClass> extends TestBedBuilder<TClass> {
+export class SociableTestBedBuilderImpl<TClass> extends TestBedBuilder<TClass> implements SociableTestBedBuilder<TClass> {
   private readonly classesToExpose: Type[] = [];
   private readonly boundaryClasses: Type[] = [];
   private mode: 'expose' | 'boundaries' | null = null;

--- a/packages/unit/src/testbed.ts
+++ b/packages/unit/src/testbed.ts
@@ -1,7 +1,7 @@
 import { SuitesDIAdapters, SuitesDoublesAdapters, testBedBuilderFactory } from './testbed-builder.js';
 import type { Type } from '@suites/types.common';
 import {
-  SociableTestBedBuilder as SociableTestBedBuilderCore,
+  SociableTestBedBuilderImpl,
   SolitaryTestBedBuilder as SolitaryTestBedBuilderCore,
 } from '@suites/core.unit';
 import type { SociableTestBedBuilder, SolitaryTestBedBuilder } from '@suites/core.unit';
@@ -77,7 +77,7 @@ export class TestBed {
     targetClass: Type<TClass>
   ): SociableTestBedBuilder<TClass> {
     return testBedBuilderFactory(SuitesDIAdapters, SuitesDoublesAdapters, targetClass).create(
-      SociableTestBedBuilderCore<TClass>
+      SociableTestBedBuilderImpl<TClass>
     );
   }
 }

--- a/packages/unit/src/types.ts
+++ b/packages/unit/src/types.ts
@@ -2,7 +2,7 @@ import type { IdentifierMetadata } from '@suites/types.di';
 import type { DeepPartial, Type } from '@suites/types.common';
 import type { ArgsType, Stub, StubbedInstance } from '@suites/types.doubles';
 import type {
-  SociableTestBedBuilder as SociableTestBedBuilderCore,
+  SociableTestBedBuilder,
   TestBedBuilder as TestBedBuilderCore,
   UnitReference as UnitReferenceCore,
   MockOverride as MockOverrideCore,
@@ -26,28 +26,8 @@ import type {
  */
 export type Mocked<T> = StubbedInstance<T>;
 
-export interface SociableTestBedBuilder<TClass> extends SociableTestBedBuilderCore<TClass> {
-  /**
-   * Exposes a dependency to be included in the test environment in its real or partially mocked state.
-   * This method is used to selectively expose dependencies that should not be fully mocked.
-   * It allows for sociable testing, where the class under test interacts with real implementations
-   * or partial mocks of certain dependencies.
-   *
-   * @since 3.0.0
-   * @template TClass The type of the class under test.
-   * @param dependency The dependency to be exposed in its real or partially mocked state.
-   * @returns A TestBedBuilder instance for further configuration.
-   * @example
-   * import { TestBed } from '@suites/unit';
-   * import { MyService, AnotherService } from './my-service';
-   *
-   * const { unit, unitRef } = await TestBed.sociable(MyService).expose(AnotherService).compile();
-   * // MyService is now tested with AnotherService exposed and not fully mocked.
-   * @see https://suites.dev/docs/api-reference/testbed-sociable
-   * @param dependency
-   */
-  expose(dependency: Type): SociableTestBedBuilder<TClass>;
-}
+// Re-export SociableTestBedBuilder from core
+export type { SociableTestBedBuilder };
 
 export interface SolitaryTestBedBuilder<TClass> extends TestBedBuilder<TClass> {}
 


### PR DESCRIPTION
## Summary

Fixes a bug where TypeScript incorrectly allowed `.mock()` to be called directly after `TestBed.sociable()`, when it should only be available after calling `.expose()` or `.boundaries()`.

## The Problem

When using `TestBed.sociable()`, users could incorrectly chain `.mock()` immediately:

```typescript
// ❌ This should be a TypeScript error, but wasn't
TestBed.sociable(UserService).mock(SomeDependency);
```

The issue was caused by **TypeScript's declaration merging**. When an interface and class share the same name in the same module, TypeScript automatically merges their declarations. Since the `SociableTestBedBuilder` class extended `TestBedBuilder` (which has the `mock()` method), that method became part of the public API even though the interface didn't explicitly define it.

## The Solution

Applied the standard TypeScript pattern for separating public API from implementation:

1. **Interface (Public API)** - Removed `extends TestBedBuilder<TClass>` from the `SociableTestBedBuilder` interface, so it only includes the methods we explicitly define
2. **Implementation Class** - Renamed to `SociableTestBedBuilderImpl` to prevent declaration merging while still extending `TestBedBuilder` for internal functionality
3. **Factory Method** - Returns the interface type while creating the implementation class

This ensures TypeScript enforces the correct API contract:

```typescript
// ❌ TypeScript Error: Property 'mock' does not exist on type 'SociableTestBedBuilder'
TestBed.sociable(UserService).mock(SomeDependency);

// ✅ Works: .mock() is available after .expose()
TestBed.sociable(UserService)
  .expose(RealDep)
  .mock(MockedDep)
  .impl(() => ({}));

// ✅ Works: .mock() is available after .boundaries()
TestBed.sociable(UserService)
  .boundaries([BoundaryDep])
  .mock(MockedDep)
  .impl(() => ({}));
```

## Changes

- **packages/core/src/services/builders/sociable-unit-builder.ts**
  - Removed `extends TestBedBuilder<TClass>` from `SociableTestBedBuilder` interface
  - Renamed implementation class from `SociableTestBedBuilder` to `SociableTestBedBuilderImpl`
  - Added `@internal` JSDoc tag to implementation class
  - Class still extends `TestBedBuilder` and implements the interface
  
- **packages/unit/src/testbed.ts**
  - Updated to import and use `SociableTestBedBuilderImpl` for instantiation
  - Factory method still returns `SociableTestBedBuilder` interface type
  
- **packages/unit/src/types.ts**
  - Re-exported `SociableTestBedBuilder` as pure interface type from core
  
- **Test files**
  - Updated all test files to use `SociableTestBedBuilderImpl` for direct instantiation

## Test Plan

- ✅ All 105 existing tests pass
- ✅ TypeScript correctly prevents `.mock()` after `.sociable()` (TS2339 error)
- ✅ `.mock()` works correctly after `.expose()` or `.boundaries()`
- ✅ Build successful for all packages