### PR TITLE
fix(types.doubles): add missing @suites/types.common dependency

### DIFF
--- a/packages/types/doubles/package.json
+++ b/packages/types/doubles/package.json
@@ -25,6 +25,9 @@
     "test": "jest --passWithNoTests",
     "lint": "yarn eslint 'index.ts'"
   },
+  "dependencies": {
+    "@suites/types.common": "^3.0.0"
+  },
   "files": [
     "index.d.ts"
   ],


### PR DESCRIPTION
## Problem
`@suites/types.doubles` imports `DeepPartial` from `@suites/types.common` (index.ts:1) but the dependency is not declared in package.json.

This causes:
- TypeScript build failures
- npm publish validation errors
- Broken dependency resolution

## Changes
- Add `@suites/types.common` dependency to `packages/types/doubles/package.json`

## Impact
- **Patch fix** for v3.0.1
- Fixes build errors
- Allows proper npm publishing
- No breaking changes

## Files Changed
- `packages/types/doubles/package.json` - Added missing dependency