### PR TITLE
ci: use GH_TOKEN for branch push and remove e2e from publish workflow

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -31,18 +31,8 @@ on:
         default: 'next'
 
 jobs:
-  e2e:
-    name: E2E Release Simulation
-    uses: ./.github/workflows/e2e-release.yml
-    with:
-      target_branch: ${{ github.event.inputs.target_branch }}
-    permissions:
-      contents: write
-      id-token: write
-
   publish:
     name: Publish to NPM
-    needs: [e2e]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -59,6 +59,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.target_branch }}
           fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Setup Node
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Changes

- **release-packages.yml**: use `GH_TOKEN` secret on checkout so lerna can push the version bump commit directly to protected branches
- **publish-packages.yml**: remove the E2E simulation job and its `needs` dependency — E2E already runs during Prepare Release, no need to repeat it on publish