### PR TITLE
fix(unit): remove direct Mocked and Stub exports to fix TS2300

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -8,6 +8,7 @@ on:
         options:
           - 'graduate'
           - 'prerelease'
+          - 'stable'
         required: true
         default: 'prerelease'
       target_branch:
@@ -103,6 +104,12 @@ jobs:
       - name: Graduate Version
         if: ${{ github.event.inputs.release_type == 'graduate' }}
         run: npx lerna version --conventional-graduate --yes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Stable Version
+        if: ${{ github.event.inputs.release_type == 'stable' }}
+        run: npx lerna version --conventional-commits --yes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/e2e/esm/jest/nestjs/package.json
+++ b/e2e/esm/jest/nestjs/package.json
@@ -19,7 +19,7 @@
     "typescript": "^5.x"
   },
   "scripts": {
-    "test": "tsc --noEmit && NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" NODE_NO_WARNINGS=1 jest",
+    "test": "tsc --noEmit && tsc -p tsconfig.skipLibCheck.json --noEmit && NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" NODE_NO_WARNINGS=1 jest",
     "lint": "eslint '**/*.ts'"
   },
   "engines": {

--- a/e2e/esm/jest/nestjs/tsconfig.skipLibCheck.json
+++ b/e2e/esm/jest/nestjs/tsconfig.skipLibCheck.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "skipLibCheck": false
+  }
+}

--- a/e2e/jest/inversify/package.json
+++ b/e2e/jest/inversify/package.json
@@ -10,7 +10,7 @@
     "reflect-metadata": "^0.2.0"
   },
   "scripts": {
-    "test": "tsc --noEmit && jest",
+    "test": "tsc --noEmit && tsc -p tsconfig.skipLibCheck.json --noEmit && jest",
     "lint": "eslint '**/*.ts'"
   },
   "devDependencies": {

--- a/e2e/jest/inversify/tsconfig.skipLibCheck.json
+++ b/e2e/jest/inversify/tsconfig.skipLibCheck.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "skipLibCheck": false
+  }
+}

--- a/e2e/jest/nestjs/package.json
+++ b/e2e/jest/nestjs/package.json
@@ -18,7 +18,7 @@
     "typescript": "^5.x"
   },
   "scripts": {
-    "test": "tsc --noEmit && jest",
+    "test": "tsc --noEmit && tsc -p tsconfig.skipLibCheck.json --noEmit && jest",
     "lint": "eslint '**/*.ts'"
   },
   "engines": {

--- a/e2e/jest/nestjs/tsconfig.skipLibCheck.json
+++ b/e2e/jest/nestjs/tsconfig.skipLibCheck.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "skipLibCheck": false
+  }
+}

--- a/e2e/sinon/inversify/package.json
+++ b/e2e/sinon/inversify/package.json
@@ -10,7 +10,7 @@
     "reflect-metadata": "^0.2.0"
   },
   "scripts": {
-    "test": "tsc --noEmit && ts-mocha **/*.e2e.test.ts",
+    "test": "tsc --noEmit && tsc -p tsconfig.skipLibCheck.json --noEmit && ts-mocha **/*.e2e.test.ts",
     "lint": "eslint '**/*.ts'"
   },
   "devDependencies": {

--- a/e2e/sinon/inversify/tsconfig.skipLibCheck.json
+++ b/e2e/sinon/inversify/tsconfig.skipLibCheck.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "skipLibCheck": false
+  }
+}

--- a/e2e/sinon/nestjs/package.json
+++ b/e2e/sinon/nestjs/package.json
@@ -11,7 +11,7 @@
     "reflect-metadata": "^0.2.0"
   },
   "scripts": {
-    "test": "tsc --noEmit && ts-mocha **/*.e2e.test.ts",
+    "test": "tsc --noEmit && tsc -p tsconfig.skipLibCheck.json --noEmit && ts-mocha **/*.e2e.test.ts",
     "lint": "eslint '**/*.ts'"
   },
   "devDependencies": {

--- a/e2e/sinon/nestjs/tsconfig.skipLibCheck.json
+++ b/e2e/sinon/nestjs/tsconfig.skipLibCheck.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "skipLibCheck": false
+  }
+}

--- a/packages/unit/src/index.ts
+++ b/packages/unit/src/index.ts
@@ -2,9 +2,7 @@ export { TestBed } from './testbed.js';
 export type {
   UnitTestBed,
   TestBedBuilder,
-  Mocked,
   SolitaryTestBedBuilder,
   SociableTestBedBuilder,
 } from './types.js';
 export type { UnitReference, MockOverride } from '@suites/core.unit';
-export type { Stub } from '@suites/types.doubles';


### PR DESCRIPTION
## Summary

- Remove `Mocked` and `Stub` direct exports from `@suites/unit` barrel to fix TS2300 duplicate identifier errors when `skipLibCheck: false`
- Add `skipLibCheck: false` type-check to jest and sinon E2E scenarios to prevent regression
- Add `stable` release type to prepare-release workflow

Closes #1017