### PR TITLE
test(e2e): match issue reporter setup with NodeNext moduleResolution

### DIFF
--- a/e2e/esm/jest/nestjs/tsconfig.skipLibCheck.json
+++ b/e2e/esm/jest/nestjs/tsconfig.skipLibCheck.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "skipLibCheck": false
+    "skipLibCheck": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
   }
 }

--- a/e2e/jest/inversify/tsconfig.skipLibCheck.json
+++ b/e2e/jest/inversify/tsconfig.skipLibCheck.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "skipLibCheck": false
+    "skipLibCheck": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
   }
 }

--- a/e2e/jest/nestjs/tsconfig.skipLibCheck.json
+++ b/e2e/jest/nestjs/tsconfig.skipLibCheck.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "skipLibCheck": false
+    "skipLibCheck": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
   }
 }

--- a/e2e/sinon/inversify/tsconfig.skipLibCheck.json
+++ b/e2e/sinon/inversify/tsconfig.skipLibCheck.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "skipLibCheck": false
+    "skipLibCheck": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
   }
 }

--- a/e2e/sinon/nestjs/tsconfig.skipLibCheck.json
+++ b/e2e/sinon/nestjs/tsconfig.skipLibCheck.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "skipLibCheck": false
+    "skipLibCheck": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
   }
 }


### PR DESCRIPTION
## Summary

- Update `skipLibCheck` tsconfigs to use `module: NodeNext` and `moduleResolution: NodeNext` to match the exact setup from issue #1017

Follow-up to #1020