### PR TITLE
feat(unit): bundle llm kit for ai coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Using Suites? <a href="https://github.com/suites-dev/suites/discussions/655">Sha
 
 - **AI Ready** - Provides a concise and strict test API that minimizes context requirements for LLM-based coding agents, enabling higher-quality generated tests, clearer and more actionable error messages that guide automatic self-correction, and a higher likelihood of completing test authoring in a single pass.
 
+## AI Coding Agents
+
+Suites bundles version-matched documentation for AI coding agents (Claude Code, Cursor, Copilot, others) inside the `@suites/unit` npm package. After install, the docs sit at `node_modules/@suites/unit/dist/llm/knowledge/`. Drop a short `AGENTS.md` into your project root to point agents at them, and they will generate tests against the API you actually have rather than stale patterns from training data.
+
+See [Using Suites with AI coding agents](packages/unit/README.md#using-suites-with-ai-coding-agents) in the `@suites/unit` README for the two snippets to copy in.
+
 ## Examples
 
 ### Solitary Mode

--- a/packages/unit/README.md
+++ b/packages/unit/README.md
@@ -76,6 +76,38 @@ npm i -D @suites/doubles.jest @suites/di.nestjs
 
 [**Complete installation and setup guide**](https://suites.dev/docs/get-started/installation)
 
+## Using Suites with AI coding agents
+
+Suites ships its own documentation for AI coding agents (Claude Code, Cursor, GitHub Copilot, others) bundled inside the npm package. The docs are version-matched to the version you install, so the agent always references the API you actually have, not stale patterns from its training data.
+
+After `npm install @suites/unit`, the docs sit at `node_modules/@suites/unit/dist/llm/knowledge/`. To wire them up, add these two files to the root of your project.
+
+**`AGENTS.md`** (most AI agents read this automatically):
+
+```md
+<!-- BEGIN:suites-agent-rules -->
+
+# Suites: read testing guidance before writing tests
+
+When writing or modifying tests in this project, first read the relevant doc
+in `node_modules/@suites/unit/dist/llm/knowledge/`. Start with `index.md`.
+
+These docs are version-matched to the installed `@suites/*` packages and
+override your training data.
+
+<!-- END:suites-agent-rules -->
+```
+
+**`CLAUDE.md`** (only if you use Claude Code):
+
+```md
+@AGENTS.md
+```
+
+The comment markers delimit the Suites-managed section. Future updates of this README replace only what's between them, so your own additions outside the markers are safe.
+
+This follows the same pattern Vercel adopted for Next.js 16.2 (see their [agent eval benchmark](https://vercel.com/blog/agents-md-outperforms-skills-in-our-agent-evals), where bundled docs drove pass rate from 53% to 100%).
+
 ## Community
 
 Join the Suites community on [GitHub Discussions](https://github.com/suites-dev/suites/discussions).

--- a/packages/unit/build.sh
+++ b/packages/unit/build.sh
@@ -10,3 +10,5 @@ done
 find dist/esm -type f -name "*.esm.d.ts" | while read file; do
   mv "$file" "${file%.esm.d.ts}.d.ts"
 done
+
+node ./scripts/copy-llm.mjs

--- a/packages/unit/llm/knowledge/common-mistakes.md
+++ b/packages/unit/llm/knowledge/common-mistakes.md
@@ -1,0 +1,181 @@
+---
+name: common-mistakes
+version: "3.x"
+audience: agent
+---
+
+# Common Mistakes
+
+You will see the following patterns in your training data. Do not write them. Each entry shows the WRONG shape, the RIGHT shape, and why.
+
+## 1. Calling `Test.createTestingModule` for a unit test
+
+WRONG:
+```ts
+import { Test } from '@nestjs/testing';
+const module = await Test.createTestingModule({
+  providers: [UserService, { provide: UserRepository, useValue: { findById: jest.fn() } }],
+}).compile();
+const service = module.get(UserService);
+```
+
+RIGHT:
+```ts
+import { TestBed, type Mocked } from '@suites/unit';
+const { unit, unitRef } = await TestBed.solitary(UserService).compile();
+const repo: Mocked<UserRepository> = unitRef.get(UserRepository);
+```
+
+Why: `TestBed.solitary()` reads class metadata directly and auto-generates mocks for every dependency. No module wiring, no provider lists.
+
+## 2. Hand-writing mock objects for token-injected dependencies
+
+WRONG:
+```ts
+const fakeDb = { query: jest.fn(), insert: jest.fn() };
+const service = new OrderService(fakeDb as any);
+```
+
+RIGHT:
+```ts
+const { unit, unitRef } = await TestBed.solitary(OrderService).compile();
+const db = unitRef.get<Database>('DATABASE');
+db.query.mockResolvedValue([{ id: 1 }]);
+```
+
+Why: `unitRef.get()` returns a fully-typed `Mocked<T>` where every method is a stub. Hand-rolled fakes drift from the real interface and rot silently.
+
+## 3. `jest.mock()` / `vi.mock()` on `@suites/*` or first-party modules
+
+WRONG:
+```ts
+jest.mock('@suites/unit');
+jest.mock('../user.repository');
+import { UserService } from './user.service';
+```
+
+RIGHT:
+```ts
+import { TestBed } from '@suites/unit';
+const { unit, unitRef } = await TestBed.solitary(UserService).compile();
+const repo = unitRef.get(UserRepository);
+repo.findById.mockResolvedValue({ id: '1' });
+```
+
+Why: If the dep is constructor-injected, Suites already mocked it; you are double-mocking. If it is a direct import, refactor it into an injected collaborator.
+
+## 4. `jest.spyOn(serviceUnderTest, 'privateMethod')`
+
+WRONG:
+```ts
+const { unit } = await TestBed.solitary(UserService).compile();
+const spy = jest.spyOn(unit as any, 'hashPassword').mockReturnValue('xxx');
+await unit.createUser({ email: 'a@b.c', password: 'pw' });
+expect(spy).toHaveBeenCalled();
+```
+
+RIGHT:
+```ts
+const { unit, unitRef } = await TestBed.solitary(UserService).compile();
+const hasher = unitRef.get(PasswordHasher);
+hasher.hash.mockReturnValue('xxx');
+const user = await unit.createUser({ email: 'a@b.c', password: 'pw' });
+expect(user.passwordHash).toBe('xxx');
+```
+
+Why: If you need to control a method's return value, that method belongs on a collaborator. Spying on the SUT tests the test, not the code.
+
+## 5. `.expose(SomeToken)` on a string or symbol token
+
+WRONG:
+```ts
+const { unit } = await TestBed.sociable(OrderService)
+  .expose('DATABASE')
+  .expose(DATABASE_TOKEN)
+  .compile();
+```
+
+RIGHT:
+```ts
+const { unit, unitRef } = await TestBed.sociable(OrderService)
+  .expose(PriceCalculator)
+  .compile();
+const db = unitRef.get<Database>('DATABASE');
+db.query.mockResolvedValue([]);
+```
+
+Why: `.expose()` only accepts a class constructor. Tokens represent external I/O boundaries and are always mocked. Trying to expose a token is a type error.
+
+## 6. Direct-imported (implicit) dependencies inside the class
+
+WRONG:
+```ts
+import { sendEmail } from './email-utils';
+import { logger } from './logger';
+
+@Injectable()
+export class UserService {
+  async createUser(email: string) {
+    logger.info('creating user');
+    await sendEmail(email, 'Welcome');
+  }
+}
+```
+
+RIGHT:
+```ts
+@Injectable()
+export class UserService {
+  constructor(
+    private readonly emailService: EmailService,
+    private readonly logger: Logger,
+  ) {}
+  async createUser(email: string) {
+    this.logger.info('creating user');
+    await this.emailService.send(email, 'Welcome');
+  }
+}
+```
+
+Why: Suites can only replace explicit constructor dependencies. Top-level imports execute real code in every test and cannot be intercepted.
+
+## 7. Forgetting `import 'reflect-metadata'` in Inversify test files
+
+WRONG:
+```ts
+import { TestBed } from '@suites/unit';
+import { UserService } from './user.service';
+const { unit } = await TestBed.solitary(UserService).compile();
+```
+
+RIGHT:
+```ts
+import 'reflect-metadata';
+import { TestBed } from '@suites/unit';
+import { UserService } from './user.service';
+const { unit } = await TestBed.solitary(UserService).compile();
+```
+
+Why: `reflect-metadata` patches global `Reflect` with side effects. It must run before any decorated class is loaded.
+
+## 8. Exposing a token-injected dep that is already auto-mocked
+
+WRONG:
+```ts
+const { unit, unitRef } = await TestBed.sociable(OrderService)
+  .expose(DATABASE_TOKEN)
+  .compile();
+const db = unitRef.get('DATABASE');
+```
+
+RIGHT:
+```ts
+const { unit, unitRef } = await TestBed.sociable(OrderService)
+  .expose(PriceCalculator)
+  .compile();
+const db = unitRef.get<Database>('DATABASE');
+db.query.mockResolvedValue([]);
+```
+
+Why: Token resolution fires before expose logic. The token returns a mock from `unitRef.get()` whether you ask for it or not. Pass classes to `.expose()`; pull token mocks from `unitRef`.
+

--- a/packages/unit/llm/knowledge/di-testing-with-suites.md
+++ b/packages/unit/llm/knowledge/di-testing-with-suites.md
@@ -1,0 +1,311 @@
+---
+name: di-testing-with-suites
+version: "3.x"
+audience: agent
+---
+
+# DI Testing with Suites (v3)
+
+Use this skill whenever you write or modify a unit test for a class managed by NestJS or InversifyJS. The v3 TestBed API replaces hand-rolled mocks, `Test.createTestingModule`, and Inversify container wiring.
+
+## The Three Primitives
+
+You will only call three things:
+
+1. `TestBed.solitary(Class)` returns a builder. All constructor dependencies become auto-generated mocks.
+2. `TestBed.sociable(Class)` returns a builder. Use `.expose(OtherClass)` to keep specific collaborators real. Everything else stays mocked.
+3. `unitRef.get(identifier)` returns the mock for a dependency. Pass the class for class deps, the string or symbol for token deps.
+
+Both builders end with `.compile()`, which is async and returns `{ unit, unitRef }`. `unit` is the real instance of the class under test.
+
+Never import `@nestjs/testing`. Never call `Test.createTestingModule`. Never declare a `providers: []` array. Never build an Inversify `Container` in tests.
+
+## Solitary Mode
+
+Use solitary tests to verify one class in complete isolation. Every dep (class or token) comes back as a `Mocked<T>` with all methods auto-stubbed.
+
+### NestJS + Jest
+
+```ts
+import { Injectable, Inject } from '@nestjs/common';
+import { TestBed, type Mocked } from '@suites/unit';
+
+interface AppConfig { apiUrl: string }
+
+@Injectable()
+export class UserRepository {
+  async findById(id: string): Promise<{ id: string; name: string } | null> {
+    return null;
+  }
+}
+
+@Injectable()
+export class UserService {
+  constructor(
+    private readonly repo: UserRepository,
+    @Inject('CONFIG') private readonly config: AppConfig,
+  ) {}
+
+  async getName(id: string): Promise<string | null> {
+    const user = await this.repo.findById(id);
+    return user ? user.name : null;
+  }
+}
+
+describe('UserService (solitary)', () => {
+  let service: UserService;
+  let repo: Mocked<UserRepository>;
+  let config: Mocked<AppConfig>;
+
+  beforeAll(async () => {
+    const { unit, unitRef } = await TestBed.solitary(UserService).compile();
+    service = unit;
+    repo = unitRef.get(UserRepository);
+    config = unitRef.get<AppConfig>('CONFIG');
+  });
+
+  it('returns the user name when present', async () => {
+    repo.findById.mockResolvedValue({ id: '1', name: 'Ada' });
+    await expect(service.getName('1')).resolves.toBe('Ada');
+    expect(repo.findById).toHaveBeenCalledWith('1');
+  });
+});
+```
+
+Retrieve a class mock with `unitRef.get(ClassName)`. Retrieve a token mock with `unitRef.get<Type>('TOKEN_STRING')` or `unitRef.get<Type>(SYMBOL_TOKEN)`. Configure return values per test inside `it` blocks.
+
+### InversifyJS + Vitest
+
+```ts
+import 'reflect-metadata';
+import { injectable, inject } from 'inversify';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { TestBed, type Mocked } from '@suites/unit';
+
+interface Logger { info(msg: string): void }
+
+@injectable()
+export class UserRepository {
+  async findById(id: string): Promise<{ id: string; name: string } | null> {
+    return null;
+  }
+}
+
+@injectable()
+export class UserService {
+  constructor(
+    @inject(UserRepository) private readonly repo: UserRepository,
+    @inject('Logger') private readonly logger: Logger,
+  ) {}
+
+  async getName(id: string): Promise<string | null> {
+    this.logger.info(`fetch ${id}`);
+    const user = await this.repo.findById(id);
+    return user ? user.name : null;
+  }
+}
+
+describe('UserService (Inversify solitary)', () => {
+  let service: UserService;
+  let repo: Mocked<UserRepository>;
+  let logger: Mocked<Logger>;
+
+  beforeAll(async () => {
+    const { unit, unitRef } = await TestBed.solitary(UserService).compile();
+    service = unit;
+    repo = unitRef.get(UserRepository);
+    logger = unitRef.get<Logger>('Logger');
+  });
+
+  it('logs and returns name', async () => {
+    repo.findById.mockResolvedValue({ id: '1', name: 'Ada' });
+    await expect(service.getName('1')).resolves.toBe('Ada');
+    expect(logger.info).toHaveBeenCalledWith('fetch 1');
+  });
+});
+```
+
+`import 'reflect-metadata'` is mandatory once per Inversify test file (or via a setup file).
+
+## Sociable Mode
+
+Use sociable tests to verify a class together with the real implementations of selected collaborators. Sociable tests are still unit tests because token-injected deps (DBs, HTTP clients, caches) remain mocked. `.expose(Class)` accepts a class constructor only; everything not exposed stays mocked. You cannot retrieve an exposed class via `unitRef.get()`; it is the real instance.
+
+```ts
+import { Injectable, Inject } from '@nestjs/common';
+import { TestBed, type Mocked } from '@suites/unit';
+
+interface Database { users: { save(u: { email: string }): Promise<{ id: number; email: string }> } }
+
+@Injectable()
+export class EmailValidator {
+  isValid(email: string): boolean {
+    return email.includes('@') && email.includes('.');
+  }
+}
+
+@Injectable()
+export class UserService {
+  constructor(
+    private readonly validator: EmailValidator,
+    @Inject('DATABASE') private readonly db: Database,
+  ) {}
+
+  async createUser(email: string) {
+    if (!this.validator.isValid(email)) throw new Error('Invalid email');
+    return this.db.users.save({ email });
+  }
+}
+
+describe('UserService (sociable)', () => {
+  let service: UserService;
+  let db: Mocked<Database>;
+
+  beforeAll(async () => {
+    const { unit, unitRef } = await TestBed.sociable(UserService)
+      .expose(EmailValidator)
+      .compile();
+
+    service = unit;
+    db = unitRef.get<Database>('DATABASE');
+  });
+
+  it('saves a valid user through real validation', async () => {
+    db.users.save.mockResolvedValue({ id: 1, email: 'a@b.io' });
+    await expect(service.createUser('a@b.io')).resolves.toEqual({ id: 1, email: 'a@b.io' });
+  });
+
+  it('rejects invalid input via real validator', async () => {
+    await expect(service.createUser('nope')).rejects.toThrow('Invalid email');
+    expect(db.users.save).not.toHaveBeenCalled();
+  });
+});
+```
+
+To expose multiple classes, chain `.expose()` calls: `.expose(A).expose(B).expose(C)`.
+
+## Token-Injected Dependencies Are Natural Walls
+
+Tokens are always mocked. This rule is absolute and applies in both solitary and sociable modes. A "token" is anything that is not a concrete class identifier:
+
+- String tokens: `@Inject('CONFIG')`, `@inject('Logger')`
+- Symbol tokens: `@Inject(Symbol.for('REDIS'))`, `@inject(TYPES.Repo)`
+- Inversify `LazyServiceIdentifier`: `@inject(new LazyServiceIdentifier(() => AuthService))`
+- NestJS-wrapped tokens: `@InjectRepository(Entity)` resolves to a string token via `getRepositoryToken`
+
+Token-injected deps represent external boundaries (DB, HTTP, caches, config). Suites mocks them automatically. Never add a token to `.expose()`. Never write a manual mock for a token dep.
+
+```ts
+const cfg = unitRef.get<AppConfig>('CONFIG');
+const repo = unitRef.get<Repository<User>>(getRepositoryToken(User) as string);
+```
+
+## Pre-Compile Configuration (Shared Across the File)
+
+Use `.mock(dep).final(impl)` or `.mock(dep).impl(stubFn => ({...}))` before `.compile()` when every test in the file needs the same dep behavior. `.final()` freezes the mock and removes it from `unitRef.get()`; use it for static config and primitive tokens. `.impl()` keeps the mock retrievable so each test can refine it.
+
+```ts
+const { unit, unitRef } = await TestBed.solitary(PaymentService)
+  .mock<AppConfig>('CONFIG')
+  .final({ apiUrl: 'https://test.local', currency: 'USD' })
+  .mock(PaymentGateway)
+  .impl(stubFn => ({
+    charge: stubFn().mockResolvedValue({ status: 'ok' }),
+  }))
+  .compile();
+
+// CONFIG cannot be retrieved (final).
+const gateway = unitRef.get(PaymentGateway);
+gateway.charge.mockResolvedValueOnce({ status: 'declined' });
+```
+
+## Per-Test Configuration
+
+For varying behavior across `it` blocks, leave the dep auto-mocked at compile time and configure it inside each test on the retrieved mock (`mockResolvedValue`, `mockReturnValue`, `mockResolvedValueOnce` for Jest/Vitest; `.resolves`/`.returns` for Sinon).
+
+```ts
+it('handles success', async () => {
+  repo.findById.mockResolvedValue({ id: '1', name: 'Ada' });
+  await expect(service.getName('1')).resolves.toBe('Ada');
+});
+
+it('handles missing user', async () => {
+  repo.findById.mockResolvedValue(null);
+  await expect(service.getName('1')).resolves.toBeNull();
+});
+```
+
+## NestJS Specifics
+
+`forwardRef(() => Class)` is resolved automatically. Retrieve by the plain class, not the wrapper:
+
+```ts
+@Injectable()
+export class UserService {
+  constructor(@Inject(forwardRef(() => AuthService)) private auth: AuthService) {}
+}
+
+const { unitRef } = await TestBed.solitary(UserService).compile();
+const auth = unitRef.get(AuthService); // not forwardRef(...)
+```
+
+Required `tsconfig.json` flags: `"experimentalDecorators": true` and `"emitDecoratorMetadata": true`. Property injection (`@Inject(Dep) private dep!: Dep`) works the same as constructor injection.
+
+## InversifyJS Specifics
+
+`new LazyServiceIdentifier(() => Class)` is resolved automatically. Retrieve by the underlying class:
+
+```ts
+@injectable()
+class UserService {
+  constructor(
+    @inject(new LazyServiceIdentifier(() => AuthService)) private auth: AuthService,
+  ) {}
+}
+
+const auth = unitRef.get(AuthService);
+```
+
+For tagged or named bindings (multiple bindings sharing an identifier), pass metadata as the second argument:
+
+```ts
+const katana = unitRef.get<Weapon>('Weapon', { canThrow: false });
+const shuriken = unitRef.get<Weapon>('Weapon', { canThrow: true });
+```
+
+Always start Inversify test files (or their setup file) with `import 'reflect-metadata'`.
+
+## Doubles Adapter Selection
+
+Install exactly one doubles adapter per project: `@suites/doubles.jest`, `@suites/doubles.vitest`, or `@suites/doubles.sinon`. Add a `global.d.ts` reference so `Mocked<T>` resolves from `@suites/unit`:
+
+```ts
+/// <reference types='@suites/doubles.jest/unit' />
+/// <reference types='@suites/di.nestjs/types' />
+```
+
+Swap the two lines for your runner and DI adapter. Suites auto-detects the installed packages at runtime.
+
+## What NOT to Do
+
+- Do not use `Test.createTestingModule({ providers: [...] }).compile()` from `@nestjs/testing`. Replace with `TestBed.solitary` or `TestBed.sociable`.
+- Do not create `new Container(); container.bind(...).to(...)` to wire test doubles. Replace with `TestBed.solitary`.
+- Do not hand-build mock objects cast as `any` or `as unknown as Mocked<T>`. Use `unitRef.get(Class)`.
+- Do not write a manual mock for a token dependency. Tokens are auto-mocked. Retrieve with `unitRef.get<T>('TOKEN')`.
+- Do not call `jest.mock('@suites/...')` or `vi.mock('@suites/...')`. Never mock the Suites packages themselves.
+- Do not call `jest.spyOn` on a real instance built outside TestBed. Get the mock with `unitRef.get(Dep)` and assert on it directly.
+- Do not pass a token to `.expose()`. `.expose()` accepts class constructors only. Tokens are walls.
+- Do not call `.boundaries([Class])` or `.collaborate().exclude([Class])`. Those APIs do not exist in v3. Use `.expose(Class)`.
+- Do not call `.using({...})` on a mock. The v3 builder uses `.final(impl)` (immutable) and `.impl(stubFn => impl)` (retrievable).
+
+## Decision Checklist
+
+Before writing the test:
+
+1. One class in isolation? `TestBed.solitary(Class)`.
+2. One class plus selected real collaborators? `TestBed.sociable(Class).expose(Real1).expose(Real2)`.
+3. External I/O dep (DB, HTTP, cache, config)? It is a token. Auto-mocked. Retrieve with `unitRef.get<T>('TOKEN')`.
+4. Same fake in every test? Pre-compile with `.mock(dep).final(...)` or `.mock(dep).impl(...)`.
+5. Different fake per test? Leave auto-mocked, configure in each `it` via the retrieved mock.
+
+The whole v3 unit-testing API surface is `TestBed.solitary`, `TestBed.sociable`, `.expose`, `.mock().final`, `.mock().impl`, `.compile`, and `unitRef.get`.

--- a/packages/unit/llm/knowledge/index.md
+++ b/packages/unit/llm/knowledge/index.md
@@ -1,0 +1,38 @@
+---
+name: index
+version: "3.x"
+audience: agent
+---
+
+# Suites knowledge for AI coding agents
+
+You are about to write or modify a unit test in a project that uses `@suites/unit`. Read the file from this directory that matches what you are doing. The content here is version-matched to the installed `@suites/*` packages and overrides whatever you learned during training.
+
+## What to read, by task
+
+| What you are doing | Read this file |
+|---|---|
+| Writing your first test in this project, or unsure where to start | `di-testing-with-suites.md` |
+| Picking between isolated and integrated tests | `solitary-vs-sociable.md` |
+| Refreshing on general unit-test discipline (framework-agnostic) | `writing-tests.md` |
+| About to use `Test.createTestingModule`, `jest.spyOn`, or `vi.mock` | `common-mistakes.md` first |
+| Configuring mocks for `@Inject('TOKEN')` or symbol-keyed dependencies | `solitary-vs-sociable.md`, then `di-testing-with-suites.md` |
+
+## The three rules you must not break
+
+1. Use `TestBed.solitary(YourClass)` or `TestBed.sociable(YourClass)`. Never use NestJS's `Test.createTestingModule` for a unit test that exercises a single class.
+2. Token-injected dependencies (`@Inject('TOKEN')`, symbols, `LazyServiceIdentifier`) are auto-mocked. Never hand-build a mock object for them. Never pass a token to `.expose(...)`.
+3. Configure mocks through the API Suites gives you. Pre-compile, shared across tests: `.mock(Dep).final(impl)` (frozen, not retrievable) or `.mock(Dep).impl(stubFn => impl)` (retrievable). Per-test: `unitRef.get(Dep).method.mockReturnValue(...)`. Do not call `jest.mock('@suites/...')`, `vi.mock`, or `jest.spyOn` on the unit under test.
+
+## Reading order if you have no specific task
+
+1. `writing-tests.md` (general unit-test discipline, framework-agnostic)
+2. `di-testing-with-suites.md` (the Suites API: `solitary`, `sociable`, `unitRef`)
+3. `solitary-vs-sociable.md` (when to use which mode)
+4. `common-mistakes.md` (anti-patterns to avoid)
+
+## Where this content comes from
+
+This directory is bundled inside the installed `@suites/unit` npm package at `node_modules/@suites/unit/dist/llm/knowledge/`. It ships from the Suites monorepo. The version of these docs matches the version of `@suites/unit` you have installed; mismatched API guidance is impossible by construction.
+
+If you need to verify the package version, look at the installed `package.json`. If you find a file in this directory that contradicts the installed library, treat the installed library as authoritative and stop following these docs.

--- a/packages/unit/llm/knowledge/solitary-vs-sociable.md
+++ b/packages/unit/llm/knowledge/solitary-vs-sociable.md
@@ -1,0 +1,135 @@
+---
+name: solitary-vs-sociable
+version: "3.x"
+audience: agent
+---
+
+## Default rule
+
+Default to solitary. Reach for sociable only when the behavior under test is the orchestration of real collaborators, and a solitary test cannot express that contract without lying.
+
+Solitary is the safer choice for the same reasons a small surface is safer than a wide one. Every real collaborator you pull in is another class whose construction, side effects, and bugs leak into the test. Sociable mode earns its place when collaborator interaction is the point of the test, not when it is incidental.
+
+## Solitary in one sentence
+
+`TestBed.solitary(Class)` builds the unit with every constructor dependency auto-mocked, so the test pins down the unit's own behavior in isolation.
+
+```ts
+const { unit, unitRef } = await TestBed.solitary(UserService).compile();
+const userApi = unitRef.get(UserApi);
+userApi.getRandom.mockResolvedValue({ id: 1, name: 'John' });
+```
+
+## Sociable in one sentence
+
+`TestBed.sociable(Class).expose(Collaborator)` builds the unit with everything still auto-mocked by default, then promotes the listed collaborators to their real implementations so the test exercises the real wiring between them.
+
+```ts
+const { unit, unitRef } = await TestBed.sociable(OrderService)
+  .expose(PricingService)
+  .expose(TaxCalculator)
+  .compile();
+```
+
+## Token-injected dependencies are walls (LOAD-BEARING)
+
+Anything injected by a non-class identifier is always auto-mocked. This includes:
+
+- `@Inject('STRING_TOKEN')` (string tokens)
+- `@Inject(SYMBOL_TOKEN)` (symbol tokens)
+- `LazyServiceIdentifier` wrappers
+- Any identifier where `typeof identifier !== 'function'`
+
+Token resolution fires before mode-specific logic. `.expose('DATABASE')` is meaningless and silently ignored: the token has no constructor, so there is nothing to instantiate as real. The same is true for symbols and lazy identifiers. If you want a real implementation of a thing, that thing must be a class.
+
+Wrong. The token cannot be exposed:
+
+```ts
+@Injectable()
+export class UserService {
+  constructor(
+    private readonly validator: EmailValidator,
+    @Inject('DATABASE') private readonly db: DatabaseClient,
+  ) {}
+}
+
+const { unit } = await TestBed.sociable(UserService)
+  .expose(EmailValidator)
+  .expose('DATABASE') // useless, the token stays mocked
+  .compile();
+```
+
+Right. The token stays mocked, and you configure it through `unitRef`:
+
+```ts
+const { unit, unitRef } = await TestBed.sociable(UserService)
+  .expose(EmailValidator)
+  .compile();
+
+const db = unitRef.get<DatabaseClient>('DATABASE');
+db.users.save.mockResolvedValue({ id: 1, email: 'a@b.co' });
+```
+
+The corollary is liberating. You never have to think about I/O when picking a mode. Databases, HTTP clients, caches, and config providers are injected through tokens by convention, so they are mocked for free. Sociable tests stay unit tests because the I/O boundary is a natural wall, not something the agent has to remember to plug.
+
+## When sociable is right
+
+Pick sociable when the answer to "what is being tested?" includes a verb between two classes.
+
+- Pricing pipelines: `OrderService` calls `PricingService` calls `DiscountEngine`, and the bug surface is the composition. Stubbing the pricing return value would force the test to encode the very arithmetic you want to verify.
+- Validation chains: `UserService` delegates to `EmailValidator`, and the validator's real rules are part of the contract you care about. Mocking `isValid` to return `true` proves nothing about the rules.
+- Policy and rule objects: small pure classes where stubbing the return value is equivalent to copying the production logic into the test. Expose them and let the real code run.
+- Refactor coverage during graph reshuffles: when extracting a helper class out of a unit, sociable mode keeps the existing test honest across the move without rewriting every assertion.
+
+## When sociable is wrong
+
+Pick solitary (or refactor first) when any of the following holds.
+
+- The collaborator does I/O, even indirectly. Move the I/O behind a token and let it auto-mock. Do not expose a class that wraps a database call.
+- The collaborator has module-level side effects: top-level await, lifecycle hooks that fire on construction, global singletons that self-initialize. Real instantiation runs that code, and the test pays for it on every run.
+- The collaborator is expensive: ML inference, heavy parsing, large fixtures, schema compilation. The test gets slow and flaky for no behavioral gain over a stubbed return.
+- The bug under test lives entirely inside the unit. Pulling in real collaborators widens blast radius when something breaks and makes failure attribution harder.
+
+## Side effects in sociable mode
+
+Sociable mode constructs real classes. Anything those classes do at import time or in their constructor will execute during the test, and Suites cannot intercept it. The most common offenders:
+
+- Top-level await: `export const db = await connect()`
+- Barrel files (`index.ts`) that re-export modules with side effects
+- `NestFactory.create()` at module scope
+- Lifecycle hooks invoked in the constructor
+- Global singletons initialized eagerly
+- Environment variable validation that throws on import
+- `@Inject('CONFIG')` providers whose factory validates eagerly
+
+If a collaborator triggers any of these, do not expose it. Either keep it mocked (in v3 non-exposed class deps come back as mocks with `undefined` returns, so configure them deliberately via `unitRef`), or refactor it behind a token so the wall fires automatically. `.expose()` cannot protect you from code that runs at import time. It only controls what happens during DI resolution, which is Phase 2; side effects already fired in Phase 1.
+
+## Decision flowchart
+
+```
+Q1. Is the dependency injected by string token, symbol, or LazyServiceIdentifier?
+     YES -> Already auto-mocked. Do not try to expose it. Configure through unitRef.
+     NO  -> continue.
+
+Q2. Is the behavior under test "this one class's logic"?
+     YES -> TestBed.solitary(Class). Stop.
+     NO  -> continue.
+
+Q3. Is the behavior under test the interaction between this class and one or more real collaborators?
+     NO  -> TestBed.solitary(Class). Stop.
+     YES -> continue.
+
+Q4. Does any candidate collaborator do I/O, run top-level side effects, or cost real time to instantiate?
+     YES -> Refactor it behind a token, or keep it mocked. Do not expose.
+     NO  -> continue.
+
+Q5. Would stubbing the collaborator's return value be equivalent to copying its production logic into the test?
+     YES -> Strong signal to expose it. The real class is the contract.
+     NO  -> Lean toward solitary; the collaborator is a detail, not part of the unit's contract.
+
+Q6. After exposing, do non-exposed class dependencies still have a sensible mocked default?
+     YES -> TestBed.sociable(Class).expose(...).compile(). Configure remaining mocks via unitRef.
+     NO  -> Drop back to solitary and configure stubs explicitly.
+```
+
+Apply the questions in order. The first three eliminate most cases without ever reaching for sociable. The last three keep sociable honest when you do.

--- a/packages/unit/llm/knowledge/writing-tests.md
+++ b/packages/unit/llm/knowledge/writing-tests.md
@@ -1,0 +1,139 @@
+---
+name: writing-tests
+version: "3.x"
+audience: agent
+---
+
+## The point of a unit test
+
+A unit test exists to pin down a behavioral contract: given these inputs and these collaborators, the unit produces these outputs and these effects. It is a specification expressed in code. It is not a coverage receipt, not a re-tracing of the implementation, and not a proof that the function executed. A line being executed is not evidence that the line is correct. Write the test so that the contract survives every refactor the implementation will not.
+
+## Constructor injection over service locators or direct imports
+
+Dependencies the unit reaches for itself are dependencies you cannot replace. They turn the unit into a closed circuit: the test runs the real collaborator, or it does not run at all.
+
+Before. The unit reaches out:
+
+```ts
+import { db } from "./infra/db";
+import { clock } from "./infra/clock";
+
+export class InvoiceService {
+  async finalize(id: string) {
+    const invoice = await db.invoices.findById(id);
+    invoice.finalizedAt = clock.now();
+    await db.invoices.save(invoice);
+    return invoice;
+  }
+}
+```
+
+There is no seam. The test either touches a real database and a real clock, or it monkey-patches the module graph. Both options are bad.
+
+After. Dependencies arrive through the constructor:
+
+```ts
+export class InvoiceService {
+  constructor(
+    private readonly invoices: InvoiceRepository,
+    private readonly clock: Clock,
+  ) {}
+
+  async finalize(id: string) {
+    const invoice = await this.invoices.findById(id);
+    invoice.finalizedAt = this.clock.now();
+    await this.invoices.save(invoice);
+    return invoice;
+  }
+}
+```
+
+Now the unit has explicit collaborators with named types. The test composes the unit with fakes or mocks of those collaborators and asserts on the contract that runs between them.
+
+## Mock at architectural boundaries only
+
+A boundary is something the unit does not own: HTTP, the database, the file system, the clock, the random number generator, the network, a third-party SDK. These are legitimate seams. Mocking them is honest because their real implementations are nondeterministic, slow, or outside your process.
+
+Internal helpers are not boundaries. They are the unit working. If you mock them, your test asserts that the implementation called itself in a particular order. That is not a contract; that is a transcript.
+
+Before. Mocking an internal collaborator the unit owns:
+
+```ts
+const formatter = { format: vi.fn().mockReturnValue("X") };
+const service = new ReportService(formatter);
+service.render(input);
+expect(formatter.format).toHaveBeenCalledWith(input);
+```
+
+The test passes whenever the implementation calls a function named `format`. Rename the helper, inline it, replace it with a switch, and the test fails for reasons unrelated to behavior.
+
+After. Mock the real boundary, assert on the observable output:
+
+```ts
+const http = { post: vi.fn().mockResolvedValue({ status: 200 }) };
+const service = new ReportService(http);
+
+const result = await service.render(input);
+
+expect(result).toEqual({ ok: true, url: "https://reports/123" });
+expect(http.post).toHaveBeenCalledWith("/reports", { body: input });
+```
+
+The boundary is HTTP; the contract is what the unit sends and what it returns.
+
+## One behavior per `it`. AAA structure.
+
+Each test names a single behavior and proves it. Arrange the world, act once, assert on the outcome. If you find yourself writing a second `act` in the same `it`, you have two tests.
+
+```ts
+it("marks the invoice as finalized at the current time", async () => {
+  // Arrange
+  const invoice = { id: "i-1", finalizedAt: null };
+  const invoices = { findById: async () => invoice, save: vi.fn() };
+  const clock = { now: () => new Date("2026-01-01T00:00:00Z") };
+  const service = new InvoiceService(invoices, clock);
+
+  // Act
+  const result = await service.finalize("i-1");
+
+  // Assert
+  expect(result.finalizedAt).toEqual(new Date("2026-01-01T00:00:00Z"));
+  expect(invoices.save).toHaveBeenCalledWith(result);
+});
+```
+
+The name describes the behavior in business terms. A reader who never opens the implementation should still understand what the unit promises.
+
+## Test the contract, not the implementation
+
+The contract is what the unit accepts, what it returns, and what it does to its collaborators at the boundary. Everything else is private. Private fields, private methods, the order of internal calls, intermediate variables, branch coverage of helper functions: none of that is a contract.
+
+Spying on a private method is a smell. It signals that the test could not observe the behavior through the public surface and reached inside to grade the work. If a behavior is not visible through the public API, either the API is wrong or the behavior is not worth testing.
+
+## Implicit vs explicit dependencies
+
+A direct import inside a class body is an implicit dependency. The class compiles without the test ever naming it. A constructor parameter is an explicit dependency. The signature lists everything the unit needs.
+
+Explicit dependencies are the seam that makes tests possible without monkey-patching. They also document the unit: a reader of the constructor knows the full collaborator set without scanning the body.
+
+Prefer constructor parameters for anything that crosses a boundary, anything stateful, anything nondeterministic, and anything you might want to replace. Pure standalone functions and value types can stay as imports.
+
+## Anti-patterns
+
+- `jest.spyOn` or `vi.spyOn` on the unit under test. You are mocking the thing you are supposed to be verifying.
+- `vi.mock` or `jest.mock` of first-party modules to swap a real collaborator. Use constructor injection instead.
+- Tests that mirror the implementation's control flow. If reordering two independent statements in the unit breaks the test, the test is overfit.
+- Asserting on the number of times an internal helper was called. Call counts on private collaborators are implementation, not contract.
+- "It passes locally." A test that depends on machine time, file system state, network, or installation order is not a unit test.
+- Snapshot tests as a substitute for assertions. A snapshot codifies whatever the implementation happened to produce, including the bugs.
+- One `it` with five `expect` blocks covering five behaviors. Split them.
+
+## Checklist
+
+- The unit takes its collaborators through the constructor.
+- Mocks exist only for things the unit does not own.
+- Each `it` names one behavior and exercises one action.
+- Assertions describe outcomes a caller could observe, not internal calls.
+- Renaming a private method does not break any test.
+- The test would still pass after a reasonable refactor of the unit body.
+- No global state, no real clock, no real network, no real file system.

--- a/packages/unit/llm/skills/suites-test/SKILL.md
+++ b/packages/unit/llm/skills/suites-test/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: suites-test
+description: Use the Suites DI testing API correctly whenever a file imports from @suites/unit, @suites/doubles.*, or references TestBed. Prefer TestBed.solitary(ClassUnderTest) for isolated unit tests; TestBed.sociable(ClassUnderTest).expose(Collaborator) when a real class collaborator participates. Token-injected dependencies are auto-mocked by Suites; never hand-build mocks for them. Do NOT use Test.createTestingModule (NestJS native, not Suites) and do NOT mix the two. Always read node_modules/@suites/unit/dist/llm/knowledge/ for current API. TRIGGER on any edit to a file that imports @suites/* or contains TestBed.. SKIP for plain Jest/Vitest tests with no Suites import.
+version: "1.0.0"
+---
+
+# Suites Testing
+
+You are writing a test that uses Suites. Suites generates a `TestBed` for a class under test, reads its DI metadata, and produces auto-mocks for every dependency. Before writing, read the bundled knowledge files at `node_modules/@suites/unit/dist/llm/knowledge/` for the version installed in this project. The recipes below describe the v3 (master) API: `TestBed.solitary()`, `TestBed.sociable().expose()`, `.mock(Dep).final(impl)` (frozen, not retrievable), `.mock(Dep).impl(stubFn => impl)` (retrievable). Do NOT use `.using(...)`, `.boundaries(...)`, `.collaborate()`, or `.exclude()`: those are older syntax or different branches and will not compile against v3.
+
+## Solitary recipe
+
+Use `TestBed.solitary(ClassUnderTest)` when you want one class tested with every dependency replaced by an auto-mock. This is the default. Reach for it first.
+
+```ts
+import { TestBed, type Mocked } from '@suites/unit';
+import { UserService } from './user.service';
+import { UserRepository } from './user.repository';
+import { EmailService } from './email.service';
+
+describe('UserService (solitary)', () => {
+  let service: UserService;
+  let repo: Mocked<UserRepository>;
+  let email: Mocked<EmailService>;
+
+  beforeAll(async () => {
+    const { unit, unitRef } = await TestBed.solitary(UserService).compile();
+    service = unit;
+    repo = unitRef.get(UserRepository);
+    email = unitRef.get(EmailService);
+  });
+
+  it('persists a new user and sends a welcome email', async () => {
+    repo.save.mockResolvedValue({ id: 1, email: 'a@b.c' });
+
+    const result = await service.createUser({ email: 'a@b.c' });
+
+    expect(result.id).toBe(1);
+    expect(email.sendWelcome).toHaveBeenCalledWith('a@b.c');
+  });
+});
+```
+
+Pre-compile configuration is available when several tests share the same default. Configure on the auto-mock retrieved from `unitRef` in `beforeAll`, or branch per-test in `beforeEach`.
+
+## Sociable recipe
+
+Use `TestBed.sociable(ClassUnderTest).expose(Collaborator)` when a real class collaborator is part of the behavior under test. Sociable tests are still unit tests: external I/O stays mocked. Use sociable when an inner business class is small, deterministic, and has no I/O of its own.
+
+```ts
+import { TestBed, type Mocked } from '@suites/unit';
+import { UserService } from './user.service';
+import { UserValidator } from './user.validator';
+import { UserRepository } from './user.repository';
+import { DATABASE_TOKEN, type Database } from './database';
+
+describe('UserService (sociable)', () => {
+  let service: UserService;
+  let database: Mocked<Database>;
+
+  beforeAll(async () => {
+    const { unit, unitRef } = await TestBed.sociable(UserService)
+      .expose(UserValidator)
+      .expose(UserRepository)
+      .compile();
+
+    service = unit;
+    database = unitRef.get<Database>(DATABASE_TOKEN);
+  });
+
+  it('rejects an invalid email through the real validator', async () => {
+    await expect(service.createUser({ email: 'not-an-email' }))
+      .rejects.toThrow(/email/i);
+    expect(database.users.insert).not.toHaveBeenCalled();
+  });
+
+  it('inserts a valid user through the real repository', async () => {
+    database.users.insert.mockResolvedValue({ id: 7, email: 'a@b.c' });
+
+    const user = await service.createUser({ email: 'a@b.c' });
+
+    expect(user.id).toBe(7);
+    expect(database.users.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'a@b.c' })
+    );
+  });
+});
+```
+
+Only `.expose()` a class when its real behavior is what the test is verifying. Do not expose a class just because it exists.
+
+## Token-injected dependencies
+
+Token-injected dependencies (`@Inject('DATABASE')`, `@Inject(LOGGER_TOKEN)`, symbol or string tokens, repository tokens from TypeORM, etc.) are **natural walls** in the dependency graph. Suites mocks them automatically and unconditionally. You do not need to configure anything for them to be mocked.
+
+`.expose(TOKEN)` does not work and is conceptually wrong. `.expose()` resolves a class constructor and instantiates the real class; a token is not a constructor, there is nothing to instantiate. Tokens represent external systems (database, HTTP client, cache, config). External systems are the boundary, they stay mocked.
+
+Correct alternative: retrieve the auto-mock via `unitRef.get<T>(TOKEN)` after compile and configure it like any other mock.
+
+```ts
+const { unit, unitRef } = await TestBed.sociable(UserService)
+  .expose(UserValidator)
+  .compile();
+
+const database = unitRef.get<Database>(DATABASE_TOKEN);
+database.users.insert.mockResolvedValue({ id: 1 });
+
+const logger = unitRef.get<Logger>('LOGGER');
+logger.info.mockReturnValue(undefined);
+```
+
+If the constructor uses `@InjectRepository(UserEntity)` (TypeORM), retrieve with the repository token:
+
+```ts
+import { getRepositoryToken } from '@nestjs/typeorm';
+const repo = unitRef.get<Repository<UserEntity>>(getRepositoryToken(UserEntity) as string);
+```
+
+For Inversify tagged or named bindings, pass the metadata as the second argument:
+
+```ts
+const katana = unitRef.get<Weapon>('Weapon', { canThrow: false });
+const usersDb = unitRef.get<Database>('Database', { name: 'users' });
+```
+
+## Do NOT
+
+- Do not use `Test.createTestingModule` from `@nestjs/testing`. That is NestJS's native test module; it bootstraps a full DI container and has nothing to do with Suites. Pick one tool per test file.
+- Do not mix the two in the same file. If a spec imports both `TestBed` from `@suites/unit` and `Test` from `@nestjs/testing`, delete one.
+- Do not hand-build mocks (`{ save: jest.fn(), find: jest.fn() }`) and pass them to a Suites TestBed. Every dependency is already auto-mocked. Configure the auto-mock retrieved from `unitRef`.
+- Do not call `jest.mock` / `vi.mock` on the unit's collaborators. Suites already replaced them.
+- Do not `.expose()` a token (string or symbol). Tokens are walls. Configure the auto-mock instead.
+- Do not `.expose()` a class that performs real I/O. If exposing it would hit a network or database, it should be behind a token instead, refactor.
+- Do not call `unit.something()` to wire dependencies after compile. Compile returns the fully wired unit.
+
+## Per-test vs per-file configuration
+
+- **`beforeAll` + compile once**, when every `it` in the file uses the same exposed collaborators. Cheaper. Reset per-test mock state in `beforeEach` if your runner does not do it for you.
+- **`beforeEach` + compile per test**, when one test needs to expose something the others do not, or when shared mock state would leak between tests in confusing ways. Slower; only when needed.
+
+Configure mock return values inside each `it` (or in a focused `beforeEach`) rather than at the top of the file. Tests should read top-to-bottom.
+
+## Adapter selection
+
+Suites separates the doubles library (Jest / Sinon / Vitest) from the DI adapter (NestJS / Inversify). Install one of each, plus `@suites/unit`.
+
+| Concern | Package | Install when |
+|---|---|---|
+| Doubles | `@suites/doubles.jest` | Tests run under Jest |
+| Doubles | `@suites/doubles.sinon` | Tests run under Sinon / Mocha |
+| Doubles | `@suites/doubles.vitest` | Tests run under Vitest |
+| DI | `@suites/di.nestjs` | Project uses `@Injectable()` / `@Inject()` |
+| DI | `@suites/di.inversify` | Project uses `@injectable()` / `@inject()` |
+
+Suites detects installed adapters automatically. Do not configure them manually unless the project README says so. Both adapters require `experimentalDecorators` and `emitDecoratorMetadata` in `tsconfig.json` and `import 'reflect-metadata'` at the entry of test files (Inversify especially).
+
+## Quick checklist
+
+- The file imports `TestBed` from `@suites/unit`, not `Test` from `@nestjs/testing`.
+- The default choice is `TestBed.solitary(ClassUnderTest).compile()`.
+- `.expose()` is used only when the test verifies the real behavior of an inner business class.
+- Tokens are never passed to `.expose()`. Token mocks are accessed via `unitRef.get<T>(TOKEN)`.
+- No hand-built mock objects, no `jest.mock` of collaborators, no `Test.createTestingModule`.
+- Asserts target the unit's return value or the boundary mock's calls, not the unit's private methods.
+- Doubles, DI adapter, and `@suites/unit` versions are aligned and present in `package.json`.

--- a/packages/unit/llm/skills/writing-unit-tests/SKILL.md
+++ b/packages/unit/llm/skills/writing-unit-tests/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: writing-unit-tests
+description: Apply universal unit-test discipline when writing or modifying test files in any TypeScript/JavaScript project. Use constructor injection over service-locator lookups; mock only at architectural boundaries (HTTP, DB, clock, randomness); never spy on internal methods of the unit under test; never use vi.mock or jest.mock on first-party modules; one behavior per it block; AAA structure. TRIGGER on any edit to *.spec.ts, *.test.ts, __tests__/*, files that add describe/it blocks, or questions like "how should I test this". SKIP for E2E or integration tests where boundary mocking rules invert.
+version: "1.0.0"
+---
+
+# Writing Unit Tests
+
+You are writing or modifying a unit test. A unit test verifies one piece of behavior by driving the unit under test through its public surface, with collaborators replaced only where they cross an architectural boundary. This skill encodes the rules. Follow them as written; they are not suggestions.
+
+## Core principles
+
+1. **Constructor inject, do not service-locate.** Pass collaborators in through the constructor (or factory parameters). Do not import singletons inside the unit, and do not reach for `container.get()` mid-method. If you cannot swap a collaborator from the test without monkey-patching, the design is wrong, fix the design first.
+
+2. **Mock only at architectural boundaries.** A boundary is a place where your process talks to something it does not own: HTTP, database, message broker, file system, clock, randomness, external SDK. Everything inside that wall is real. First-party business logic is never a boundary.
+
+3. **Never spy on internal methods of the unit under test.** The unit's private methods are not part of the contract. If a test asserts `expect(service.computeFoo).toHaveBeenCalled()`, the test will break on the next harmless refactor. Assert on observable behavior: return values, calls to boundary doubles, thrown errors, state changes you can read through the public API.
+
+4. **Never `vi.mock`/`jest.mock` first-party modules.** Module-level mocking of your own code is a symptom of implicit dependencies. The fix is to make the dependency explicit through the constructor, not to patch the import system. Reserve module mocking for genuine boundaries you cannot otherwise inject (a third-party SDK that exports a default singleton, for example).
+
+5. **One behavior per `it`.** Each test has one reason to fail. If your test name needs "and", split it. The Arrange / Act / Assert structure should be visible at a glance: setup, one call, one (logical) assertion block.
+
+6. **Boundaries earn the asserts.** Verification is most valuable at the edges of the unit. Assert the value the caller receives, and assert the calls made to the boundary doubles. Do not assert intermediate computations.
+
+## Common anti-patterns
+
+### spyOn the unit under test
+
+```ts
+// WRONG: implementation-coupled, breaks on any rename
+it('creates user', async () => {
+  const spy = jest.spyOn(service as any, 'hashPassword');
+  await service.createUser({ email: 'a@b.c', password: 'x' });
+  expect(spy).toHaveBeenCalled();
+});
+
+// RIGHT: assert at the boundary the hash actually reaches
+it('persists user with hashed password', async () => {
+  await service.createUser({ email: 'a@b.c', password: 'x' });
+  expect(userRepository.save).toHaveBeenCalledWith(
+    expect.objectContaining({ email: 'a@b.c', passwordHash: expect.any(String) })
+  );
+});
+```
+
+### jest.mock of a first-party module
+
+```ts
+// WRONG: pretends the module system is the dependency boundary
+jest.mock('../email/email-utils');
+import { sendEmail } from '../email/email-utils';
+
+// RIGHT: make EmailService explicit, inject it
+class UserService {
+  constructor(private readonly email: EmailService) {}
+}
+```
+
+### Mocking a pure function
+
+```ts
+// WRONG: stubbing your own date formatter buys nothing and breaks on refactor
+jest.spyOn(formatters, 'formatDate').mockReturnValue('2026-01-01');
+
+// RIGHT: call it for real; assert the final output
+expect(invoice.renderedAt).toMatch(/^\d{4}-\d{2}-\d{2}/);
+```
+
+### Multi-behavior test
+
+```ts
+// WRONG: one it covering three behaviors. One failure hides the others.
+it('handles user creation', async () => {
+  await expect(service.createUser({ email: '' })).rejects.toThrow();
+  await service.createUser({ email: 'ok@x.com' });
+  expect(repo.save).toHaveBeenCalled();
+  await expect(service.createUser({ email: 'ok@x.com' })).rejects.toThrow();
+});
+
+// RIGHT: one behavior, one it
+it('rejects empty email', async () => { /* ... */ });
+it('persists a valid user', async () => { /* ... */ });
+it('rejects duplicate email', async () => { /* ... */ });
+```
+
+## Quick checklist
+
+- The unit's collaborators arrive through the constructor; the test wires them in.
+- Doubles are placed at boundaries (HTTP, DB, clock, queue, SDK), nowhere else.
+- No `spyOn` on a method of the unit under test.
+- No `jest.mock` / `vi.mock` of first-party modules.
+- Each `it` has one observable behavior in its name and one logical assertion block.
+- Asserts target the return value, the boundary double, or a thrown error, not internal state.
+- The test would still pass after an internal rename or extract-method refactor.
+
+## When this skill does NOT apply
+
+- **E2E tests** that drive the system through its real HTTP / CLI / UI surface. Boundary mocking inverts: you want real boundaries, with only third-party external services stubbed.
+- **Integration tests** that exercise a real database, real broker, or real file system on purpose. Mocking those defeats the test's reason for existing.
+- **Performance / load tests.** The discipline above is about correctness, not throughput.
+- **Contract tests** against a published schema. Those verify the boundary itself; the rules here assume the boundary is given.
+
+If the file you are editing is clearly one of the above (path contains `e2e`, `integration`, `bench`, or the file talks to real infrastructure), stop applying this skill and follow that suite's conventions instead.

--- a/packages/unit/llm/templates/agents-block.md
+++ b/packages/unit/llm/templates/agents-block.md
@@ -1,0 +1,11 @@
+<!-- BEGIN:suites-agent-rules -->
+
+# Suites: read testing guidance before writing tests
+
+When writing or modifying tests in this project, first read the relevant doc
+in `node_modules/@suites/unit/dist/llm/knowledge/`. Start with `index.md`.
+
+These docs are version-matched to the installed `@suites/*` packages and
+override your training data.
+
+<!-- END:suites-agent-rules -->

--- a/packages/unit/llm/templates/claude-import.txt
+++ b/packages/unit/llm/templates/claude-import.txt
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/unit/package.json
+++ b/packages/unit/package.json
@@ -17,7 +17,12 @@
         "types": "./dist/cjs/index.d.ts",
         "default": "./dist/cjs/index.js"
       }
-    }
+    },
+    "./llm": "./dist/llm/knowledge/index.md",
+    "./llm/*": "./dist/llm/*"
+  },
+  "bin": {
+    "suites": "./dist/cjs/cli.js"
   },
   "keywords": [
     "unit testing",

--- a/packages/unit/scripts/copy-llm.mjs
+++ b/packages/unit/scripts/copy-llm.mjs
@@ -1,0 +1,20 @@
+// Copies packages/unit/llm/** into packages/unit/dist/llm/.
+// Mirrors Vercel's `copy_docs` + `copy_skills` taskfile pattern, adapted
+// to the tsc-based build (no taskr). Invoked at the end of build.sh.
+import { cp, access } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = join(here, '..', 'llm');
+const dst = join(here, '..', 'dist', 'llm');
+
+try {
+  await access(src);
+} catch {
+  console.error(`copy-llm: source not found at ${src}`);
+  process.exit(1);
+}
+
+await cp(src, dst, { recursive: true });
+console.log(`copy-llm: ${src} -> ${dst}`);

--- a/packages/unit/src/cli.ts
+++ b/packages/unit/src/cli.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+// Reserved CLI entry. The `bin` slot in package.json is wired now so future
+// subcommands (verify, setup-llm) can ship without a major bump.
+console.error('suites: CLI is reserved and not yet implemented in this version.');
+process.exit(2);


### PR DESCRIPTION
## Why

AI coding agents now write a meaningful share of the test code shipped against Suites. Out of the box they default to outdated training-data patterns (Automock-era APIs, `Test.createTestingModule`, `jest.spyOn` on internals). Vercel published a benchmark in March 2026 showing that bundled, version-matched docs lift agent pass rate from 53% (no docs / skill alone) to 100%, and shipped the pattern in `next@16.2`.

This PR adopts that pattern for `@suites/unit`.

## What ships

- **Knowledge layer** at `packages/unit/llm/knowledge/` (5 plain Markdown files, ~33 KB total)
- **Skills** at `packages/unit/llm/skills/` (generic `writing-unit-tests` + Suites-specific `suites-test`)
- **Templates** at `packages/unit/llm/templates/` (marker-delimited `AGENTS.md` block + one-line `CLAUDE.md` import)
- **Build wiring** that copies `llm/**` into `dist/llm/` (mirrors Vercel's `copy_docs` taskfile pattern, adapted to our tsc build)
- **Subpath exports** so consumers can reach the content from `@suites/unit/llm/knowledge/*.md`
- **Reserved `bin` slot** for the future `suites verify` CLI; v1 ships only a stub so we never need a major bump to add subcommands

## Distribution

No installer, no website work. Consumers paste two files (shown verbatim in the package README) into their project root after `npm install @suites/unit`. The docs live at `node_modules/@suites/unit/dist/llm/knowledge/`, version-matched to the installed library by construction.

## Out of scope

- `suites.dev` is intentionally untouched. The website can later mirror these docs (the way nextjs.org mirrors `vercel/next.js/docs/`) as a separate project.
- `@suites/blackbox` and `@suites/static` will follow the same pattern when their products land.
- v4 API rewrites of the knowledge content (`.collaborate()` / `.exclude()` / "Virtual Test Container") are deferred to the v4 launch.

## Verification

- `pnpm build` runs `copy-llm.mjs` and produces `dist/llm/{knowledge,skills,templates}/`
- `pnpm pack` produces a 31 KB tarball containing all kit files at `package/dist/llm/...`
- Round-trip smoke test: install the tarball into a scratch project, confirm `node_modules/@suites/unit/dist/llm/knowledge/index.md` resolves, paste the AGENTS.md block, watch Claude Code read the docs before writing a test